### PR TITLE
[BACKLOG-12334] Renaming new artifacts created by mavenization to mat…

### DIFF
--- a/assemblies/mac/pom.xml
+++ b/assemblies/mac/pom.xml
@@ -2,16 +2,16 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>assemblies-parent-pom</artifactId>
-    <groupId>pentaho-report-designer</groupId>
+    <groupId>org.pentaho.reporting</groupId>
+    <artifactId>pentaho-reporting-assemblies</artifactId>
     <version>7.1-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
-  <packaging>pom</packaging>
+
   <artifactId>prd-ce-mac</artifactId>
-  <organization>
-    <name>Pentaho Corporation</name>
-  </organization>
+  <packaging>pom</packaging>
+
+  <name>Pentaho Report Designer CE Assembly (mac)</name>
+
   <licenses>
     <license>
       <name>GNU Lesser General Public License, version 2.1</name>
@@ -19,10 +19,12 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
   <properties>
     <app.mac.dir>${stage.dir}\Pentaho Report Designer.app</app.mac.dir>
     <dist.name.mac>prd-ce-mac-${project.version}</dist.name.mac>
   </properties>
+
   <profiles>
     <profile>
       <id>mac</id>

--- a/assemblies/pom.xml
+++ b/assemblies/pom.xml
@@ -2,17 +2,15 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>pentaho-reporting-parent-pom</artifactId>
     <groupId>org.pentaho.reporting</groupId>
+    <artifactId>pentaho-reporting</artifactId>
     <version>7.1-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
   
-  <groupId>pentaho-report-designer</groupId>
-  <artifactId>assemblies-parent-pom</artifactId>
+  <artifactId>pentaho-reporting-assemblies</artifactId>
   <packaging>pom</packaging>
   
-  <name>Pentaho Reporting Designer Assemblies</name>
+  <name>Pentaho Reporting Assemblies</name>
 
   <profiles>
     <profile>
@@ -37,10 +35,12 @@
       </modules>
     </profile>
   </profiles>
+
   <properties>
     <stage.dir>${project.build.directory}\stage</stage.dir>
     <stage.dir.designer>${stage.dir}\report-designer</stage.dir.designer>
   </properties>
+
   <dependencies>
     <dependency>
       <groupId>pentaho-reporting-engine</groupId>

--- a/assemblies/winlinux/pom.xml
+++ b/assemblies/winlinux/pom.xml
@@ -2,16 +2,16 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>assemblies-parent-pom</artifactId>
-    <groupId>pentaho-report-designer</groupId>
+    <groupId>org.pentaho.reporting</groupId>
+    <artifactId>pentaho-reporting-assemblies</artifactId>
     <version>7.1-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
-  <packaging>pom</packaging>
+
   <artifactId>prd-ce</artifactId>
-  <organization>
-    <name>Pentaho Corporation</name>
-  </organization>
+  <packaging>pom</packaging>
+
+  <name>Pentaho Report Designer CE Assembly</name>
+
   <licenses>
     <license>
       <name>GNU Lesser General Public License, version 2.1</name>
@@ -19,10 +19,12 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
   <properties>
     <dist.name>prd-ce-${project.version}</dist.name>
     <dist.name.mac>prd-ce-mac-${project.version}</dist.name.mac>
   </properties>
+
   <profiles>
     <profile>
       <id>winlinux</id>

--- a/designer/datasource-editor-cda/pom.xml
+++ b/designer/datasource-editor-cda/pom.xml
@@ -2,16 +2,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>pentaho-report-designer-parent-pom</artifactId>
-    <groupId>pentaho-report-designer</groupId>
+    <groupId>org.pentaho.reporting</groupId>
+    <artifactId>pentaho-reporting-designer</artifactId>
     <version>7.1-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
+
   <groupId>pentaho-reporting-engine</groupId>
   <artifactId>pentaho-reporting-engine-datasource-editor-cda</artifactId>
-  <organization>
-    <name>Pentaho Corporation</name>
-  </organization>
+
   <licenses>
     <license>
       <name>GNU Lesser General Public License, version 2.1</name>
@@ -19,6 +17,7 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/designer/datasource-editor-external/pom.xml
+++ b/designer/datasource-editor-external/pom.xml
@@ -2,16 +2,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>pentaho-report-designer-parent-pom</artifactId>
-    <groupId>pentaho-report-designer</groupId>
+    <groupId>org.pentaho.reporting</groupId>
+    <artifactId>pentaho-reporting-designer</artifactId>
     <version>7.1-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
+
   <groupId>pentaho-reporting-engine</groupId>
   <artifactId>pentaho-reporting-engine-datasource-editor-external</artifactId>
-  <organization>
-    <name>Pentaho Corporation</name>
-  </organization>
+
   <licenses>
     <license>
       <name>GNU Lesser General Public License, version 2.1</name>
@@ -19,6 +17,7 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/designer/datasource-editor-jdbc/pom.xml
+++ b/designer/datasource-editor-jdbc/pom.xml
@@ -2,15 +2,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>pentaho-report-designer-parent-pom</artifactId>
-    <groupId>pentaho-report-designer</groupId>
+    <groupId>org.pentaho.reporting</groupId>
+    <artifactId>pentaho-reporting-designer</artifactId>
     <version>7.1-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
+
+  <groupId>pentaho-report-designer</groupId>
   <artifactId>pentaho-reporting-engine-datasource-editor-jdbc</artifactId>
-  <organization>
-    <name>Pentaho Corporation</name>
-  </organization>
+
   <licenses>
     <license>
       <name>GNU Lesser General Public License, version 2.1</name>
@@ -18,6 +17,7 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
   <dependencies>
     <dependency>
       <groupId>pentaho-reporting-engine</groupId>

--- a/designer/datasource-editor-kettle/pom.xml
+++ b/designer/datasource-editor-kettle/pom.xml
@@ -2,16 +2,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>pentaho-report-designer-parent-pom</artifactId>
-    <groupId>pentaho-report-designer</groupId>
+    <groupId>org.pentaho.reporting</groupId>
+    <artifactId>pentaho-reporting-designer</artifactId>
     <version>7.1-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
+
   <groupId>pentaho-reporting-engine</groupId>
   <artifactId>pentaho-reporting-engine-datasource-editor-kettle</artifactId>
-  <organization>
-    <name>Pentaho Corporation</name>
-  </organization>
+
   <licenses>
     <license>
       <name>GNU Lesser General Public License, version 2.1</name>
@@ -19,6 +17,7 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
   <dependencies>
     <dependency>
       <groupId>pentaho</groupId>

--- a/designer/datasource-editor-mondrian/pom.xml
+++ b/designer/datasource-editor-mondrian/pom.xml
@@ -2,16 +2,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>pentaho-report-designer-parent-pom</artifactId>
-    <groupId>pentaho-report-designer</groupId>
+    <groupId>org.pentaho.reporting</groupId>
+    <artifactId>pentaho-reporting-designer</artifactId>
     <version>7.1-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
+
   <groupId>pentaho-reporting-engine</groupId>
   <artifactId>pentaho-reporting-engine-datasource-editor-mondrian</artifactId>
-  <organization>
-    <name>Pentaho Corporation</name>
-  </organization>
+
   <licenses>
     <license>
       <name>GNU Lesser General Public License, version 2.1</name>
@@ -19,6 +17,7 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/designer/datasource-editor-olap4j/pom.xml
+++ b/designer/datasource-editor-olap4j/pom.xml
@@ -2,16 +2,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>pentaho-report-designer-parent-pom</artifactId>
-    <groupId>pentaho-report-designer</groupId>
+    <groupId>org.pentaho.reporting</groupId>
+    <artifactId>pentaho-reporting-designer</artifactId>
     <version>7.1-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
+
   <groupId>pentaho-reporting-engine</groupId>
   <artifactId>pentaho-reporting-engine-datasource-editor-olap4j</artifactId>
-  <organization>
-    <name>Pentaho Corporation</name>
-  </organization>
+
   <licenses>
     <license>
       <name>GNU Lesser General Public License, version 2.1</name>
@@ -19,6 +17,7 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/designer/datasource-editor-openerp/pom.xml
+++ b/designer/datasource-editor-openerp/pom.xml
@@ -2,15 +2,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>pentaho-report-designer-parent-pom</artifactId>
-    <groupId>pentaho-report-designer</groupId>
+    <groupId>org.pentaho.reporting</groupId>
+    <artifactId>pentaho-reporting-designer</artifactId>
     <version>7.1-SNAPSHOT</version>
   </parent>
+
   <groupId>pentaho-reporting-engine</groupId>
   <artifactId>pentaho-reporting-engine-datasource-editor-openerp</artifactId>
-  <organization>
-    <name>Pentaho Corporation</name>
-  </organization>
+
   <licenses>
     <license>
       <name>GNU Lesser General Public License, version 2.1</name>
@@ -18,6 +17,7 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/designer/datasource-editor-pmd/pom.xml
+++ b/designer/datasource-editor-pmd/pom.xml
@@ -2,16 +2,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>pentaho-report-designer-parent-pom</artifactId>
-    <groupId>pentaho-report-designer</groupId>
+    <groupId>org.pentaho.reporting</groupId>
+    <artifactId>pentaho-reporting-designer</artifactId>
     <version>7.1-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
+
   <groupId>pentaho-reporting-engine</groupId>
   <artifactId>pentaho-reporting-engine-datasource-editor-pmd</artifactId>
-  <organization>
-    <name>Pentaho Corporation</name>
-  </organization>
+
   <licenses>
     <license>
       <name>GNU Lesser General Public License, version 2.1</name>
@@ -19,6 +17,7 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
   <dependencies>
     <dependency>
       <groupId>pentaho-library</groupId>

--- a/designer/datasource-editor-reflection/pom.xml
+++ b/designer/datasource-editor-reflection/pom.xml
@@ -2,16 +2,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>pentaho-report-designer-parent-pom</artifactId>
-    <groupId>pentaho-report-designer</groupId>
+    <groupId>org.pentaho.reporting</groupId>
+    <artifactId>pentaho-reporting-designer</artifactId>
     <version>7.1-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
+
   <groupId>pentaho-reporting-engine</groupId>
   <artifactId>pentaho-reporting-engine-datasource-editor-reflection</artifactId>
-  <organization>
-    <name>Pentaho Corporation</name>
-  </organization>
+
   <licenses>
     <license>
       <name>GNU Lesser General Public License, version 2.1</name>
@@ -19,6 +17,7 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/designer/datasource-editor-scriptable/pom.xml
+++ b/designer/datasource-editor-scriptable/pom.xml
@@ -2,16 +2,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>pentaho-report-designer-parent-pom</artifactId>
-    <groupId>pentaho-report-designer</groupId>
+    <groupId>org.pentaho.reporting</groupId>
+    <artifactId>pentaho-reporting-designer</artifactId>
     <version>7.1-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
+
   <groupId>pentaho-reporting-engine</groupId>
   <artifactId>pentaho-reporting-engine-datasource-editor-scriptable</artifactId>
-  <organization>
-    <name>Pentaho Corporation</name>
-  </organization>
+
   <licenses>
     <license>
       <name>GNU Lesser General Public License, version 2.1</name>
@@ -19,6 +17,7 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/designer/datasource-editor-table/pom.xml
+++ b/designer/datasource-editor-table/pom.xml
@@ -2,16 +2,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>pentaho-report-designer-parent-pom</artifactId>
-    <groupId>pentaho-report-designer</groupId>
+    <groupId>org.pentaho.reporting</groupId>
+    <artifactId>pentaho-reporting-designer</artifactId>
     <version>7.1-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
+
   <groupId>pentaho-reporting-engine</groupId>
   <artifactId>pentaho-reporting-engine-datasource-editor-table</artifactId>
-  <organization>
-    <name>Pentaho Corporation</name>
-  </organization>
+
   <licenses>
     <license>
       <name>GNU Lesser General Public License, version 2.1</name>
@@ -19,6 +17,7 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/designer/datasource-editor-xpath/pom.xml
+++ b/designer/datasource-editor-xpath/pom.xml
@@ -2,16 +2,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>pentaho-report-designer-parent-pom</artifactId>
-    <groupId>pentaho-report-designer</groupId>
+    <groupId>org.pentaho.reporting</groupId>
+    <artifactId>pentaho-reporting-designer</artifactId>
     <version>7.1-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
+
   <groupId>pentaho-reporting-engine</groupId>
   <artifactId>pentaho-reporting-engine-datasource-editor-xpath</artifactId>
-  <organization>
-    <name>Pentaho Corporation</name>
-  </organization>
+
   <licenses>
     <license>
       <name>GNU Lesser General Public License, version 2.1</name>
@@ -19,6 +17,7 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/designer/pom.xml
+++ b/designer/pom.xml
@@ -2,18 +2,21 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>pentaho-reporting-parent-pom</artifactId>
     <groupId>org.pentaho.reporting</groupId>
+    <artifactId>pentaho-reporting</artifactId>
     <version>7.1-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
-  
-  <groupId>pentaho-report-designer</groupId>
-  <artifactId>pentaho-report-designer-parent-pom</artifactId>
+
+  <groupId>org.pentaho.reporting</groupId>
+  <artifactId>pentaho-reporting-designer</artifactId>
   <packaging>pom</packaging>
   
-  <name>Pentaho Reporting Designer Build Aggregator</name>
+  <name>Pentaho Reporting Designer Modules</name>
   
+  <properties>
+    <junit.sysprop.java.awt.headless>true</junit.sysprop.java.awt.headless>
+  </properties>
+
   <modules>
     <module>report-designer</module>
     <module>wizard-xul</module>
@@ -36,7 +39,4 @@
     <module>report-designer-extension-wizard</module>   
   </modules>
 
-  <properties>
-    <junit.sysprop.java.awt.headless>true</junit.sysprop.java.awt.headless>
-  </properties>
 </project>

--- a/designer/report-designer-extension-connectioneditor/pom.xml
+++ b/designer/report-designer-extension-connectioneditor/pom.xml
@@ -2,15 +2,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>pentaho-report-designer-parent-pom</artifactId>
-    <groupId>pentaho-report-designer</groupId>
+    <groupId>org.pentaho.reporting</groupId>
+    <artifactId>pentaho-reporting-designer</artifactId>
     <version>7.1-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
+
+  <groupId>pentaho-report-designer</groupId>
   <artifactId>report-designer-ext-connection-editor</artifactId>
-  <organization>
-    <name>Pentaho Corporation</name>
-  </organization>
+
   <licenses>
     <license>
       <name>GNU Lesser General Public License, version 2.1</name>
@@ -18,6 +17,7 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/designer/report-designer-extension-legacy-charts/pom.xml
+++ b/designer/report-designer-extension-legacy-charts/pom.xml
@@ -2,15 +2,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>pentaho-report-designer-parent-pom</artifactId>
-    <groupId>pentaho-report-designer</groupId>
+    <groupId>org.pentaho.reporting</groupId>
+    <artifactId>pentaho-reporting-designer</artifactId>
     <version>7.1-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
+
+  <groupId>pentaho-report-designer</groupId>
   <artifactId>report-designer-ext-legacy-charts</artifactId>
-  <organization>
-    <name>Pentaho Corporation</name>
-  </organization>
+
   <licenses>
     <license>
       <name>GNU Lesser General Public License, version 2.1</name>
@@ -18,6 +17,7 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/designer/report-designer-extension-pentaho/pom.xml
+++ b/designer/report-designer-extension-pentaho/pom.xml
@@ -2,15 +2,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>pentaho-report-designer-parent-pom</artifactId>
-    <groupId>pentaho-report-designer</groupId>
+    <groupId>org.pentaho.reporting</groupId>
+    <artifactId>pentaho-reporting-designer</artifactId>
     <version>7.1-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
+
+  <groupId>pentaho-report-designer</groupId>
   <artifactId>report-designer-ext-pentaho</artifactId>
-  <organization>
-    <name>Pentaho Corporation</name>
-  </organization>
+
   <licenses>
     <license>
       <name>GNU Lesser General Public License, version 2.1</name>
@@ -18,6 +17,7 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/designer/report-designer-extension-toc/pom.xml
+++ b/designer/report-designer-extension-toc/pom.xml
@@ -2,15 +2,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>pentaho-report-designer-parent-pom</artifactId>
-    <groupId>pentaho-report-designer</groupId>
+    <groupId>org.pentaho.reporting</groupId>
+    <artifactId>pentaho-reporting-designer</artifactId>
     <version>7.1-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
+
+  <groupId>pentaho-report-designer</groupId>
   <artifactId>report-designer-ext-toc</artifactId>
-  <organization>
-    <name>Pentaho Corporation</name>
-  </organization>
+
   <licenses>
     <license>
       <name>GNU Lesser General Public License, version 2.1</name>
@@ -18,6 +17,7 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/designer/report-designer-extension-wizard/pom.xml
+++ b/designer/report-designer-extension-wizard/pom.xml
@@ -2,15 +2,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>pentaho-report-designer-parent-pom</artifactId>
-    <groupId>pentaho-report-designer</groupId>
+    <groupId>org.pentaho.reporting</groupId>
+    <artifactId>pentaho-reporting-designer</artifactId>
     <version>7.1-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
+
+  <groupId>pentaho-report-designer</groupId>
   <artifactId>report-designer-ext-wizard</artifactId>
-  <organization>
-    <name>Pentaho Corporation</name>
-  </organization>
+
   <licenses>
     <license>
       <name>GNU Lesser General Public License, version 2.1</name>
@@ -18,6 +17,7 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/designer/report-designer/pom.xml
+++ b/designer/report-designer/pom.xml
@@ -2,15 +2,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>pentaho-report-designer-parent-pom</artifactId>
-    <groupId>pentaho-report-designer</groupId>
+    <groupId>org.pentaho.reporting</groupId>
+    <artifactId>pentaho-reporting-designer</artifactId>
     <version>7.1-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
+
+  <groupId>pentaho-report-designer</groupId>
   <artifactId>report-designer</artifactId>
-  <organization>
-    <name>Pentaho Corporation</name>
-  </organization>
+
   <licenses>
     <license>
       <name>GNU Lesser General Public License, version 2.1</name>
@@ -18,6 +17,7 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
   <properties>
     <Implementation-ProductID>PRD</Implementation-ProductID>
     <Implementation-Title>Pentaho Report Designer</Implementation-Title>

--- a/designer/wizard-xul/pom.xml
+++ b/designer/wizard-xul/pom.xml
@@ -2,15 +2,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>pentaho-report-designer-parent-pom</artifactId>
-    <groupId>pentaho-report-designer</groupId>
+    <groupId>org.pentaho.reporting</groupId>
+    <artifactId>pentaho-reporting-designer</artifactId>
     <version>7.1-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
+
+  <groupId>pentaho-report-designer</groupId>
   <artifactId>pentaho-reporting-engine-wizard-xul</artifactId>
-  <organization>
-    <name>Pentaho Corporation</name>
-  </organization>
+
   <licenses>
     <license>
       <name>GNU Lesser General Public License, version 2.1</name>
@@ -18,6 +17,7 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
   <dependencies>
     <dependency>
       <groupId>pentaho-reporting-engine</groupId>

--- a/engine/core/pom.xml
+++ b/engine/core/pom.xml
@@ -2,15 +2,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>pentaho-reporting-engine-parent-pom</artifactId>
-    <groupId>pentaho-reporting-engine</groupId>
+    <groupId>org.pentaho.reporting</groupId>
+    <artifactId>pentaho-reporting-engine</artifactId>
     <version>7.1-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
+
+  <groupId>pentaho-reporting-engine</groupId>
   <artifactId>pentaho-reporting-engine-classic-core</artifactId>
-  <organization>
-    <name>Pentaho Corporation</name>
-  </organization>
+
   <licenses>
     <license>
       <name>GNU Lesser General Public License, version 2.1</name>
@@ -18,6 +17,7 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
   <dependencies>
     <dependency>
       <groupId>pentaho-library</groupId>

--- a/engine/demo/pom.xml
+++ b/engine/demo/pom.xml
@@ -2,15 +2,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>pentaho-reporting-engine-parent-pom</artifactId>
-    <groupId>pentaho-reporting-engine</groupId>
+    <groupId>org.pentaho.reporting</groupId>
+    <artifactId>pentaho-reporting-engine</artifactId>
     <version>7.1-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
+
+  <groupId>pentaho-reporting-engine</groupId>
   <artifactId>pentaho-reporting-engine-classic-demo</artifactId>
-  <organization>
-    <name>Pentaho Corporation</name>
-  </organization>
+
   <licenses>
     <license>
       <name>GNU Lesser General Public License, version 2.1</name>
@@ -18,6 +17,7 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/engine/extensions-cda/pom.xml
+++ b/engine/extensions-cda/pom.xml
@@ -2,15 +2,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>pentaho-reporting-engine-parent-pom</artifactId>
-    <groupId>pentaho-reporting-engine</groupId>
+    <groupId>org.pentaho.reporting</groupId>
+    <artifactId>pentaho-reporting-engine</artifactId>
     <version>7.1-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
+
+  <groupId>pentaho-reporting-engine</groupId>
   <artifactId>pentaho-reporting-engine-classic-extensions-cda</artifactId>
-  <organization>
-    <name>Pentaho Corporation</name>
-  </organization>
+
   <licenses>
     <license>
       <name>GNU Lesser General Public License, version 2.1</name>
@@ -18,6 +17,7 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/engine/extensions-charting/pom.xml
+++ b/engine/extensions-charting/pom.xml
@@ -2,15 +2,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>pentaho-reporting-engine-parent-pom</artifactId>
-    <groupId>pentaho-reporting-engine</groupId>
+    <groupId>org.pentaho.reporting</groupId>
+    <artifactId>pentaho-reporting-engine</artifactId>
     <version>7.1-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
+
+  <groupId>pentaho-reporting-engine</groupId>
   <artifactId>pentaho-reporting-engine-classic-extensions-charting</artifactId>
-  <organization>
-    <name>Pentaho Corporation</name>
-  </organization>
+
   <licenses>
     <license>
       <name>GNU Lesser General Public License, version 2.1</name>
@@ -18,6 +17,7 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/engine/extensions-docsupport/pom.xml
+++ b/engine/extensions-docsupport/pom.xml
@@ -2,15 +2,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>pentaho-reporting-engine-parent-pom</artifactId>
-    <groupId>pentaho-reporting-engine</groupId>
+    <groupId>org.pentaho.reporting</groupId>
+    <artifactId>pentaho-reporting-engine</artifactId>
     <version>7.1-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
+
+  <groupId>pentaho-reporting-engine</groupId>
   <artifactId>pentaho-reporting-engine-classic-docsupport</artifactId>
-  <organization>
-    <name>Pentaho Corporation</name>
-  </organization>
+
   <licenses>
     <license>
       <name>GNU Lesser General Public License, version 2.1</name>
@@ -18,6 +17,7 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/engine/extensions-drilldown/pom.xml
+++ b/engine/extensions-drilldown/pom.xml
@@ -2,15 +2,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>pentaho-reporting-engine-parent-pom</artifactId>
-    <groupId>pentaho-reporting-engine</groupId>
+    <groupId>org.pentaho.reporting</groupId>
+    <artifactId>pentaho-reporting-engine</artifactId>
     <version>7.1-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
+
+  <groupId>pentaho-reporting-engine</groupId>
   <artifactId>pentaho-reporting-engine-classic-extensions-drill-down</artifactId>
-  <organization>
-    <name>Pentaho Corporation</name>
-  </organization>
+
   <licenses>
     <license>
       <name>GNU Lesser General Public License, version 2.1</name>
@@ -18,6 +17,7 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/engine/extensions-kettle/pom.xml
+++ b/engine/extensions-kettle/pom.xml
@@ -2,15 +2,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>pentaho-reporting-engine-parent-pom</artifactId>
-    <groupId>pentaho-reporting-engine</groupId>
+    <groupId>org.pentaho.reporting</groupId>
+    <artifactId>pentaho-reporting-engine</artifactId>
     <version>7.1-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
+
+  <groupId>pentaho-reporting-engine</groupId>
   <artifactId>pentaho-reporting-engine-classic-extensions-kettle</artifactId>
-  <organization>
-    <name>Pentaho Corporation</name>
-  </organization>
+
   <licenses>
     <license>
       <name>GNU Lesser General Public License, version 2.1</name>
@@ -18,6 +17,7 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/engine/extensions-mondrian/pom.xml
+++ b/engine/extensions-mondrian/pom.xml
@@ -2,15 +2,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>pentaho-reporting-engine-parent-pom</artifactId>
-    <groupId>pentaho-reporting-engine</groupId>
+    <groupId>org.pentaho.reporting</groupId>
+    <artifactId>pentaho-reporting-engine</artifactId>
     <version>7.1-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
+
+  <groupId>pentaho-reporting-engine</groupId>
   <artifactId>pentaho-reporting-engine-classic-extensions-mondrian</artifactId>
-  <organization>
-    <name>Pentaho Corporation</name>
-  </organization>
+
   <licenses>
     <license>
       <name>GNU Lesser General Public License, version 2.1</name>
@@ -18,6 +17,7 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/engine/extensions-olap4j/pom.xml
+++ b/engine/extensions-olap4j/pom.xml
@@ -2,15 +2,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>pentaho-reporting-engine-parent-pom</artifactId>
-    <groupId>pentaho-reporting-engine</groupId>
+    <groupId>org.pentaho.reporting</groupId>
+    <artifactId>pentaho-reporting-engine</artifactId>
     <version>7.1-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
+
+  <groupId>pentaho-reporting-engine</groupId>
   <artifactId>pentaho-reporting-engine-classic-extensions-olap4j</artifactId>
-  <organization>
-    <name>Pentaho Corporation</name>
-  </organization>
+
   <licenses>
     <license>
       <name>GNU Lesser General Public License, version 2.1</name>
@@ -18,6 +17,7 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/engine/extensions-openerp/pom.xml
+++ b/engine/extensions-openerp/pom.xml
@@ -2,15 +2,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>pentaho-reporting-engine-parent-pom</artifactId>
-    <groupId>pentaho-reporting-engine</groupId>
+    <groupId>org.pentaho.reporting</groupId>
+    <artifactId>pentaho-reporting-engine</artifactId>
     <version>7.1-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
+
+  <groupId>pentaho-reporting-engine</groupId>
   <artifactId>pentaho-reporting-engine-classic-extensions-openerp</artifactId>
-  <organization>
-    <name>Pentaho Corporation</name>
-  </organization>
+
   <licenses>
     <license>
       <name>GNU Lesser General Public License, version 2.1</name>
@@ -18,6 +17,7 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/engine/extensions-pentaho-metadata/pom.xml
+++ b/engine/extensions-pentaho-metadata/pom.xml
@@ -2,15 +2,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>pentaho-reporting-engine-parent-pom</artifactId>
-    <groupId>pentaho-reporting-engine</groupId>
+    <groupId>org.pentaho.reporting</groupId>
+    <artifactId>pentaho-reporting-engine</artifactId>
     <version>7.1-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
+
+  <groupId>pentaho-reporting-engine</groupId>
   <artifactId>pentaho-reporting-engine-classic-extensions-pmd</artifactId>
-  <organization>
-    <name>Pentaho Corporation</name>
-  </organization>
+
   <licenses>
     <license>
       <name>GNU Lesser General Public License, version 2.1</name>
@@ -18,6 +17,7 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/engine/extensions-reportdesigner-parser/pom.xml
+++ b/engine/extensions-reportdesigner-parser/pom.xml
@@ -2,15 +2,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>pentaho-reporting-engine-parent-pom</artifactId>
-    <groupId>pentaho-reporting-engine</groupId>
+    <groupId>org.pentaho.reporting</groupId>
+    <artifactId>pentaho-reporting-engine</artifactId>
     <version>7.1-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
+
+  <groupId>pentaho-reporting-engine</groupId>
   <artifactId>pentaho-reporting-engine-classic-extensions-reportdesigner-parser</artifactId>
-  <organization>
-    <name>Pentaho Corporation</name>
-  </organization>
+
   <licenses>
     <license>
       <name>GNU Lesser General Public License, version 2.1</name>

--- a/engine/extensions-sampledata/pom.xml
+++ b/engine/extensions-sampledata/pom.xml
@@ -2,15 +2,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>pentaho-reporting-engine-parent-pom</artifactId>
-    <groupId>pentaho-reporting-engine</groupId>
+    <groupId>org.pentaho.reporting</groupId>
+    <artifactId>pentaho-reporting-engine</artifactId>
     <version>7.1-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
+
+  <groupId>pentaho-reporting-engine</groupId>
   <artifactId>pentaho-reporting-engine-classic-extensions-sampledata</artifactId>
-  <organization>
-    <name>Pentaho Corporation</name>
-  </organization>
+
   <licenses>
     <license>
       <name>GNU Lesser General Public License, version 2.1</name>
@@ -18,6 +17,7 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/engine/extensions-scripting/pom.xml
+++ b/engine/extensions-scripting/pom.xml
@@ -2,15 +2,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>pentaho-reporting-engine-parent-pom</artifactId>
-    <groupId>pentaho-reporting-engine</groupId>
+    <groupId>org.pentaho.reporting</groupId>
+    <artifactId>pentaho-reporting-engine</artifactId>
     <version>7.1-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
+
+  <groupId>pentaho-reporting-engine</groupId>
   <artifactId>pentaho-reporting-engine-classic-extensions-scripting</artifactId>
-  <organization>
-    <name>Pentaho Corporation</name>
-  </organization>
+
   <licenses>
     <license>
       <name>GNU Lesser General Public License, version 2.1</name>
@@ -18,6 +17,7 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/engine/extensions-toc/pom.xml
+++ b/engine/extensions-toc/pom.xml
@@ -2,15 +2,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>pentaho-reporting-engine-parent-pom</artifactId>
-    <groupId>pentaho-reporting-engine</groupId>
+    <groupId>org.pentaho.reporting</groupId>
+    <artifactId>pentaho-reporting-engine</artifactId>
     <version>7.1-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
+
+  <groupId>pentaho-reporting-engine</groupId>
   <artifactId>pentaho-reporting-engine-classic-extensions-toc</artifactId>
-  <organization>
-    <name>Pentaho Corporation</name>
-  </organization>
+
   <licenses>
     <license>
       <name>GNU Lesser General Public License, version 2.1</name>
@@ -18,6 +17,7 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/engine/extensions-xpath/pom.xml
+++ b/engine/extensions-xpath/pom.xml
@@ -2,15 +2,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>pentaho-reporting-engine-parent-pom</artifactId>
-    <groupId>pentaho-reporting-engine</groupId>
+    <groupId>org.pentaho.reporting</groupId>
+    <artifactId>pentaho-reporting-engine</artifactId>
     <version>7.1-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
+
+  <groupId>pentaho-reporting-engine</groupId>
   <artifactId>pentaho-reporting-engine-classic-extensions-xpath</artifactId>
-  <organization>
-    <name>Pentaho Corporation</name>
-  </organization>
+
   <licenses>
     <license>
       <name>GNU Lesser General Public License, version 2.1</name>
@@ -18,6 +17,7 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/engine/extensions/pom.xml
+++ b/engine/extensions/pom.xml
@@ -2,15 +2,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>pentaho-reporting-engine-parent-pom</artifactId>
-    <groupId>pentaho-reporting-engine</groupId>
+    <groupId>org.pentaho.reporting</groupId>
+    <artifactId>pentaho-reporting-engine</artifactId>
     <version>7.1-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
+
+  <groupId>pentaho-reporting-engine</groupId>
   <artifactId>pentaho-reporting-engine-classic-extensions</artifactId>
-  <organization>
-    <name>Pentaho Corporation</name>
-  </organization>
+
   <licenses>
     <license>
       <name>GNU Lesser General Public License, version 2.1</name>
@@ -18,6 +17,7 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/engine/legacy-charts/pom.xml
+++ b/engine/legacy-charts/pom.xml
@@ -2,15 +2,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>pentaho-reporting-engine-parent-pom</artifactId>
-    <groupId>pentaho-reporting-engine</groupId>
+    <groupId>org.pentaho.reporting</groupId>
+    <artifactId>pentaho-reporting-engine</artifactId>
     <version>7.1-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
+
+  <groupId>pentaho-reporting-engine</groupId>
   <artifactId>pentaho-reporting-engine-legacy-charts</artifactId>
-  <organization>
-    <name>Pentaho Corporation</name>
-  </organization>
+
   <licenses>
     <license>
       <name>GNU Lesser General Public License, version 2.1</name>
@@ -18,6 +17,7 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/engine/legacy-functions/pom.xml
+++ b/engine/legacy-functions/pom.xml
@@ -2,15 +2,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>pentaho-reporting-engine-parent-pom</artifactId>
-    <groupId>pentaho-reporting-engine</groupId>
+    <groupId>org.pentaho.reporting</groupId>
+    <artifactId>pentaho-reporting-engine</artifactId>
     <version>7.1-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
+
+  <groupId>pentaho-reporting-engine</groupId>
   <artifactId>pentaho-reporting-engine-legacy-functions</artifactId>
-  <organization>
-    <name>Pentaho Corporation</name>
-  </organization>
+
   <licenses>
     <license>
       <name>GNU Lesser General Public License, version 2.1</name>
@@ -18,6 +17,7 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -2,17 +2,16 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>pentaho-reporting-parent-pom</artifactId>
     <groupId>org.pentaho.reporting</groupId>
+    <artifactId>pentaho-reporting</artifactId>
     <version>7.1-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
-  
-  <groupId>pentaho-reporting-engine</groupId>
-  <artifactId>pentaho-reporting-engine-parent-pom</artifactId>
+
+  <groupId>org.pentaho.reporting</groupId>
+  <artifactId>pentaho-reporting-engine</artifactId>
   <packaging>pom</packaging>
   
-  <name>Pentaho Reporting Engine Build Aggregator</name>
+  <name>Pentaho Reporting Engine Modules</name>
 
   <properties>
     <junit.sysprop.java.awt.headless>true</junit.sysprop.java.awt.headless>

--- a/engine/samples/pom.xml
+++ b/engine/samples/pom.xml
@@ -2,15 +2,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>pentaho-reporting-engine-parent-pom</artifactId>
-    <groupId>pentaho-reporting-engine</groupId>
+    <groupId>org.pentaho.reporting</groupId>
+    <artifactId>pentaho-reporting-engine</artifactId>
     <version>7.1-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
+
+  <groupId>pentaho-reporting-engine</groupId>
   <artifactId>pentaho-reporting-engine-classic-samples</artifactId>
-  <organization>
-    <name>Pentaho Corporation</name>
-  </organization>
+
   <licenses>
     <license>
       <name>GNU Lesser General Public License, version 2.1</name>
@@ -18,6 +17,7 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
   <dependencies>
     <dependency>
       <groupId>pentaho-reporting-engine</groupId>

--- a/engine/sdk/pom.xml
+++ b/engine/sdk/pom.xml
@@ -2,16 +2,15 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>pentaho-reporting-engine-parent-pom</artifactId>
-    <groupId>pentaho-reporting-engine</groupId>
+    <groupId>org.pentaho.reporting</groupId>
+    <artifactId>pentaho-reporting-engine</artifactId>
     <version>7.1-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
+
+  <groupId>pentaho-reporting-engine</groupId>
   <artifactId>pre-classic-sdk</artifactId>
   <packaging>jar</packaging>
-  <organization>
-    <name>Pentaho Corporation</name>
-  </organization>
+
   <licenses>
     <license>
       <name>GNU Lesser General Public License, version 2.1</name>
@@ -19,6 +18,7 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/engine/testcases/pom.xml
+++ b/engine/testcases/pom.xml
@@ -2,15 +2,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>pentaho-reporting-engine-parent-pom</artifactId>
-    <groupId>pentaho-reporting-engine</groupId>
+    <groupId>org.pentaho.reporting</groupId>
+    <artifactId>pentaho-reporting-engine</artifactId>
     <version>7.1-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
+
+  <groupId>pentaho-reporting-engine</groupId>
   <artifactId>pentaho-reporting-engine-classic-testcases</artifactId>
-  <organization>
-    <name>Pentaho Corporation</name>
-  </organization>
+
   <licenses>
     <license>
       <name>GNU Lesser General Public License, version 2.1</name>
@@ -18,6 +17,7 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/engine/tools/pom.xml
+++ b/engine/tools/pom.xml
@@ -2,15 +2,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>pentaho-reporting-engine-parent-pom</artifactId>
-    <groupId>pentaho-reporting-engine</groupId>
+    <groupId>org.pentaho.reporting</groupId>
+    <artifactId>pentaho-reporting-engine</artifactId>
     <version>7.1-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
+
+  <groupId>pentaho-reporting-engine</groupId>
   <artifactId>pentaho-reporting-engine-classic-tools</artifactId>
-  <organization>
-    <name>Pentaho Corporation</name>
-  </organization>
+
   <licenses>
     <license>
       <name>GNU Lesser General Public License, version 2.1</name>
@@ -18,6 +17,7 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/engine/wizard-core/pom.xml
+++ b/engine/wizard-core/pom.xml
@@ -2,15 +2,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>pentaho-reporting-engine-parent-pom</artifactId>
-    <groupId>pentaho-reporting-engine</groupId>
+    <groupId>org.pentaho.reporting</groupId>
+    <artifactId>pentaho-reporting-engine</artifactId>
     <version>7.1-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
+
+  <groupId>pentaho-reporting-engine</groupId>
   <artifactId>pentaho-reporting-engine-wizard-core</artifactId>
-  <organization>
-    <name>Pentaho Corporation</name>
-  </organization>
+
   <licenses>
     <license>
       <name>GNU Lesser General Public License, version 2.1</name>
@@ -18,6 +17,7 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/libraries/configuration-editor/pom.xml
+++ b/libraries/configuration-editor/pom.xml
@@ -7,19 +7,19 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>pentaho-reporting-library-parent-pom</artifactId>
-    <groupId>pentaho-library</groupId>
+    <groupId>org.pentaho.reporting</groupId>
+    <artifactId>pentaho-reporting-library</artifactId>
     <version>7.1-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
+
+  <groupId>pentaho-library</groupId>
   <artifactId>report-designer-configuration-editor</artifactId>
   <packaging>jar</packaging>
+
   <name>Config-Editor</name>
   <description>The Config-Editor is a visual editor for the configuration properties used
     in the LibBase configuration system.</description>
-  <organization>
-    <name>Pentaho Corporation</name>
-  </organization>
+
   <licenses>
     <license>
       <name>GNU Lesser General Public License, version 2.1</name>
@@ -27,6 +27,7 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/libraries/flute/pom.xml
+++ b/libraries/flute/pom.xml
@@ -2,13 +2,15 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>pentaho-reporting-library-parent-pom</artifactId>
-    <groupId>pentaho-library</groupId>
+    <groupId>org.pentaho.reporting</groupId>
+    <artifactId>pentaho-reporting-library</artifactId>
     <version>7.1-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
+
+  <groupId>pentaho-library</groupId>
   <artifactId>flute</artifactId>
   <packaging>jar</packaging>
+
   <name>Flute</name>
   <description>a derivative work of http://www.w3.org/Style/CSS/SAC/Overview.en.html
 
@@ -29,9 +31,7 @@
     stylesheets of other programms should not be affected by this change - if they
     specified things which were known not to work and start dying if it works -
     well, that's bad luck, I guess.</description>
-  <organization>
-    <name>Pentaho Corporation</name>
-  </organization>
+
   <licenses>
     <license>
       <name>W3C License</name>
@@ -39,6 +39,7 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
   <dependencies>
     <dependency>
       <groupId>org.w3c.css</groupId>

--- a/libraries/libbase/pom.xml
+++ b/libraries/libbase/pom.xml
@@ -2,21 +2,21 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>pentaho-reporting-library-parent-pom</artifactId>
-    <groupId>pentaho-library</groupId>
+    <groupId>org.pentaho.reporting</groupId>
+    <artifactId>pentaho-reporting-library</artifactId>
     <version>7.1-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
+
+  <groupId>pentaho-library</groupId>
   <artifactId>libbase</artifactId>
   <packaging>jar</packaging>
+
   <name>LibBase</name>
   <description>LibBase is a library developed to provide base services like
     logging, configuration and initialization to all other libraries
     and applications. The library is the root library for all other
     Pentaho-Reporting projects.</description>
-  <organization>
-    <name>Pentaho Corporation</name>
-  </organization>
+
   <licenses>
     <license>
       <name>GNU Lesser General Public License, version 2.1</name>
@@ -24,6 +24,7 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
   <dependencies>
     <dependency>
       <groupId>commons-logging</groupId>

--- a/libraries/libcss/pom.xml
+++ b/libraries/libcss/pom.xml
@@ -2,18 +2,18 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>pentaho-reporting-library-parent-pom</artifactId>
-    <groupId>pentaho-library</groupId>
+    <groupId>org.pentaho.reporting</groupId>
+    <artifactId>pentaho-reporting-library</artifactId>
     <version>7.1-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
+
+  <groupId>pentaho-library</groupId>
   <artifactId>libcss</artifactId>
   <packaging>jar</packaging>
+
   <name>LibCss</name>
   <description>LibCss is a CSS parsing and styling helper library. This library is deprecated.</description>
-  <organization>
-    <name>Pentaho Corporation</name>
-  </organization>
+
   <licenses>
     <license>
       <name>GNU Lesser General Public License, version 2.1</name>
@@ -21,6 +21,7 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/libraries/libdocbundle/pom.xml
+++ b/libraries/libdocbundle/pom.xml
@@ -2,13 +2,15 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>pentaho-reporting-library-parent-pom</artifactId>
-    <groupId>pentaho-library</groupId>
+    <groupId>org.pentaho.reporting</groupId>
+    <artifactId>pentaho-reporting-library</artifactId>
     <version>7.1-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
+
+  <groupId>pentaho-library</groupId>
   <artifactId>libdocbundle</artifactId>
   <packaging>jar</packaging>
+
   <name>LibDocBundle</name>
   <description>LibDocBundle is a library developed to provide a transparent
     document bundle service to applications. With LibDocBundle an
@@ -17,9 +19,7 @@
     details about the storage method itself. Therefore application
     developers do not have to deal with ZIP-Access or File-access
     by themselves.</description>
-  <organization>
-    <name>Pentaho Corporation</name>
-  </organization>
+
   <licenses>
     <license>
       <name>GNU Lesser General Public License, version 2.1</name>
@@ -27,6 +27,7 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/libraries/libfonts/pom.xml
+++ b/libraries/libfonts/pom.xml
@@ -2,22 +2,22 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>pentaho-reporting-library-parent-pom</artifactId>
-    <groupId>pentaho-library</groupId>
+    <groupId>org.pentaho.reporting</groupId>
+    <artifactId>pentaho-reporting-library</artifactId>
     <version>7.1-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
+
+  <groupId>pentaho-library</groupId>
   <artifactId>libfonts</artifactId>
   <packaging>jar</packaging>
+
   <name>LibFonts</name>
   <description>LibFonts is a library developed to support advanced layouting in Pentaho
     Reporting. This library allows to read physical files and to access
     other font system in a uniform way to extract layouting specific informations.
     LibFonts also provides heavy caching so that text processing is less
     CPU and memory intensive.</description>
-  <organization>
-    <name>Pentaho Corporation</name>
-  </organization>
+
   <licenses>
     <license>
       <name>GNU Lesser General Public License, version 2.1</name>
@@ -25,6 +25,7 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/libraries/libformat/pom.xml
+++ b/libraries/libformat/pom.xml
@@ -2,21 +2,21 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>pentaho-reporting-library-parent-pom</artifactId>
-    <groupId>pentaho-library</groupId>
+    <groupId>org.pentaho.reporting</groupId>
+    <artifactId>pentaho-reporting-library</artifactId>
     <version>7.1-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
+
+  <groupId>pentaho-library</groupId>
   <artifactId>libformat</artifactId>
   <packaging>jar</packaging>
+
   <name>LibFormat</name>
   <description>LibFormat is a library developed to provide a memory and CPU
     conservative way to format objects into Strings. LibFormat will
     later be extended to understand Excel- and OpenOffice pattern
     strings as well.</description>
-  <organization>
-    <name>Pentaho Corporation</name>
-  </organization>
+
   <licenses>
     <license>
       <name>GNU Lesser General Public License, version 2.1</name>
@@ -24,6 +24,7 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/libraries/libformula-ui/pom.xml
+++ b/libraries/libformula-ui/pom.xml
@@ -2,19 +2,19 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>pentaho-reporting-library-parent-pom</artifactId>
-    <groupId>pentaho-library</groupId>
+    <groupId>org.pentaho.reporting</groupId>
+    <artifactId>pentaho-reporting-library</artifactId>
     <version>7.1-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
+
+  <groupId>pentaho-library</groupId>
   <artifactId>libformula-ui</artifactId>
   <packaging>jar</packaging>
+
   <name>LibFormula-UI</name>
   <description>LibFormula-UI is a formula editor for OpenFormula expressions based on
     LibFormula.</description>
-  <organization>
-    <name>Pentaho Corporation</name>
-  </organization>
+
   <licenses>
     <license>
       <name>GNU Lesser General Public License, version 2.1</name>
@@ -22,6 +22,7 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/libraries/libformula/pom.xml
+++ b/libraries/libformula/pom.xml
@@ -2,20 +2,20 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>pentaho-reporting-library-parent-pom</artifactId>
-    <groupId>pentaho-library</groupId>
+    <groupId>org.pentaho.reporting</groupId>
+    <artifactId>pentaho-reporting-library</artifactId>
     <version>7.1-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
+
+  <groupId>pentaho-library</groupId>
   <artifactId>libformula</artifactId>
   <packaging>jar</packaging>
+
   <name>LibFormula</name>
   <description>LibFormula provides Excel-Style-Expressions. The implementation provided
     here is very generic and can be used in any application that needs to
     compute formulas.</description>
-  <organization>
-    <name>Pentaho Corporation</name>
-  </organization>
+
   <licenses>
     <license>
       <name>GNU Lesser General Public License, version 2.1</name>
@@ -23,6 +23,7 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/libraries/libloader/pom.xml
+++ b/libraries/libloader/pom.xml
@@ -3,22 +3,22 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <artifactId>pentaho-reporting-library-parent-pom</artifactId>
-        <groupId>pentaho-library</groupId>
+        <groupId>org.pentaho.reporting</groupId>
+        <artifactId>pentaho-reporting-library</artifactId>
         <version>7.1-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
+
+    <groupId>pentaho-library</groupId>
     <artifactId>libloader</artifactId>
     <packaging>jar</packaging>
+
     <name>LibLoader</name>
     <description>LibLoader is a general purpose resource loading framework. It has been
         designed to allow to load resources from any physical location and to
         allow the processing of that content data in a generic way, totally
         transparent to the user of that library.
     </description>
-    <organization>
-        <name>Pentaho Corporation</name>
-    </organization>
+
     <licenses>
         <license>
             <name>GNU Lesser General Public License, version 2.1</name>
@@ -26,6 +26,7 @@
             <distribution>repo</distribution>
         </license>
     </licenses>
+
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/libraries/libpensol/pom.xml
+++ b/libraries/libpensol/pom.xml
@@ -2,20 +2,20 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>pentaho-reporting-library-parent-pom</artifactId>
-    <groupId>pentaho-library</groupId>
+    <groupId>org.pentaho.reporting</groupId>
+    <artifactId>pentaho-reporting-library</artifactId>
     <version>7.1-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
+
+  <groupId>pentaho-library</groupId>
   <artifactId>libpensol</artifactId>
   <packaging>jar</packaging>
+
   <name>LibPensol</name>
   <description>LibPensol is an access layer for accessing a remote Pentaho Solution Repository
     via an Apache-VFS filesystem. It handles all HTTP calls and the parsing of
     the XML file and all client-side state managements.</description>
-  <organization>
-    <name>Pentaho Corporation</name>
-  </organization>
+
   <licenses>
     <license>
       <name>GNU Lesser General Public License, version 2.1</name>
@@ -23,6 +23,7 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/libraries/libpixie/pom.xml
+++ b/libraries/libpixie/pom.xml
@@ -2,20 +2,20 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>pentaho-reporting-library-parent-pom</artifactId>
-    <groupId>pentaho-library</groupId>
+    <groupId>org.pentaho.reporting</groupId>
+    <artifactId>pentaho-reporting-library</artifactId>
     <version>7.1-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
+
+  <groupId>pentaho-library</groupId>
   <artifactId>libpixie</artifactId>
   <packaging>jar</packaging>
+
   <name>LibPixie</name>
   <description>Pixie is a WMF-File reading library originally written by David R. Harris as
     converter for the Pixie-ImageViewer. Pixie was long time dead and is now
     resurrected as WMF-Reader and ImageProducer for Java 1.2.2 or higher.</description>
-  <organization>
-    <name>Pentaho Corporation</name>
-  </organization>
+
   <licenses>
     <license>
       <name>GNU Lesser General Public License, version 2.1</name>
@@ -23,6 +23,7 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/libraries/librepository/pom.xml
+++ b/libraries/librepository/pom.xml
@@ -2,19 +2,19 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>pentaho-reporting-library-parent-pom</artifactId>
-    <groupId>pentaho-library</groupId>
+    <groupId>org.pentaho.reporting</groupId>
+    <artifactId>pentaho-reporting-library</artifactId>
     <version>7.1-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
+
+  <groupId>pentaho-library</groupId>
   <artifactId>librepository</artifactId>
   <packaging>jar</packaging>
+
   <name>LibRepository</name>
   <description>LibRepository provides a simple abstraction layer to access bulk content that
     is organized in a hierarchical layer.</description>
-  <organization>
-    <name>Pentaho Corporation</name>
-  </organization>
+
   <licenses>
     <license>
       <name>GNU Lesser General Public License, version 2.1</name>
@@ -22,6 +22,7 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/libraries/libserializer/pom.xml
+++ b/libraries/libserializer/pom.xml
@@ -2,19 +2,19 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>pentaho-reporting-library-parent-pom</artifactId>
-    <groupId>pentaho-library</groupId>
+    <groupId>org.pentaho.reporting</groupId>
+    <artifactId>pentaho-reporting-library</artifactId>
     <version>7.1-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
+
+  <groupId>pentaho-library</groupId>
   <artifactId>libserializer</artifactId>
   <packaging>jar</packaging>
+
   <name>LibSerializer</name>
   <description>This library module contains a general serialization framework. It simplifies
     the task of writing custom serialization handlers for non-serializable classes.</description>
-  <organization>
-    <name>Pentaho Corporation</name>
-  </organization>
+
   <licenses>
     <license>
       <name>GNU Lesser General Public License, version 2.1</name>
@@ -22,6 +22,7 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/libraries/libsparkline/pom.xml
+++ b/libraries/libsparkline/pom.xml
@@ -2,21 +2,21 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>pentaho-reporting-library-parent-pom</artifactId>
-    <groupId>pentaho-library</groupId>
+    <groupId>org.pentaho.reporting</groupId>
+    <artifactId>pentaho-reporting-library</artifactId>
     <version>7.1-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
+
+  <groupId>pentaho-library</groupId>
   <artifactId>libsparkline</artifactId>
   <packaging>jar</packaging>
+
   <name>LibSparkline</name>
   <description>LibSparkline is a library developed to render sparkline graphs.
     Sparklines are small-scale bar or line-charts that are inserted
     into text to provide visualized information along with the textual
     description.</description>
-  <organization>
-    <name>Pentaho Corporation</name>
-  </organization>
+
   <licenses>
     <license>
       <name>GNU Lesser General Public License, version 2.1</name>
@@ -24,6 +24,7 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
   <dependencies>
     <dependency>
       <groupId>junit</groupId>

--- a/libraries/libswing/pom.xml
+++ b/libraries/libswing/pom.xml
@@ -2,21 +2,21 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>pentaho-reporting-library-parent-pom</artifactId>
-    <groupId>pentaho-library</groupId>
+    <groupId>org.pentaho.reporting</groupId>
+    <artifactId>pentaho-reporting-library</artifactId>
     <version>7.1-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
+
+  <groupId>pentaho-library</groupId>
   <artifactId>libswing</artifactId>
   <packaging>jar</packaging>
+
   <name>LibSwing</name>
   <description>LibSwing is a common helper class storage for design-time elements,
     so that they dont have to move into the engine project, where they
     potentially bloat up the project due to third-party dependencies or
     a large amount of code.</description>
-  <organization>
-    <name>Pentaho Corporation</name>
-  </organization>
+
   <licenses>
     <license>
       <name>GNU Lesser General Public License, version 2.1</name>
@@ -24,6 +24,7 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/libraries/libxml/pom.xml
+++ b/libraries/libxml/pom.xml
@@ -2,21 +2,21 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>pentaho-reporting-library-parent-pom</artifactId>
-    <groupId>pentaho-library</groupId>
+    <groupId>org.pentaho.reporting</groupId>
+    <artifactId>pentaho-reporting-library</artifactId>
     <version>7.1-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
+
+  <groupId>pentaho-library</groupId>
   <artifactId>libxml</artifactId>
   <packaging>jar</packaging>
+
   <name>LibXml</name>
   <description>LibXML is a namespace aware SAX-Parser utility library. It eases the
     pain of implementing non-trivial SAX input handlers. The original
     code of these classes had been written by Peter Becker for the
     JCommon library.</description>
-  <organization>
-    <name>Pentaho Corporation</name>
-  </organization>
+
   <licenses>
     <license>
       <name>GNU Lesser General Public License, version 2.1</name>
@@ -24,6 +24,7 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/libraries/pom.xml
+++ b/libraries/pom.xml
@@ -2,17 +2,16 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>pentaho-reporting-parent-pom</artifactId>
     <groupId>org.pentaho.reporting</groupId>
+    <artifactId>pentaho-reporting</artifactId>
     <version>7.1-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
   
-  <groupId>pentaho-library</groupId>
-  <artifactId>pentaho-reporting-library-parent-pom</artifactId>
+  <groupId>org.pentaho.reporting</groupId>
+  <artifactId>pentaho-reporting-library</artifactId>
   <packaging>pom</packaging>
   
-  <name>Pentaho Reporting Library Build Aggregator</name>
+  <name>Pentaho Reporting Libraries</name>
   
   <profiles>
     <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -1,21 +1,18 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>pentaho-ce-jar-parent-pom</artifactId>
     <groupId>org.pentaho</groupId>
+    <artifactId>pentaho-ce-jar-parent-pom</artifactId>
     <version>7.1-SNAPSHOT</version>
   </parent>
   
   <groupId>org.pentaho.reporting</groupId>
-  <artifactId>pentaho-reporting-parent-pom</artifactId>
+  <artifactId>pentaho-reporting</artifactId>
   <version>7.1-SNAPSHOT</version>
   <packaging>pom</packaging>
   
-  <name>Pentaho Reporting Parent Pom</name>
-  <organization>
-    <name>Pentaho Corporation</name>
-  </organization>
-  
+  <name>Pentaho Reporting</name>
+
   <licenses>
     <license>
       <name>GNU Lesser General Public License, version 2.1</name>
@@ -211,6 +208,7 @@
     <library.group>pentaho-library</library.group>
     <javacc-maven-plugin.version>2.6</javacc-maven-plugin.version>
   </properties>
+
   <dependencyManagement>
     <dependencies>
       <dependency>
@@ -3104,6 +3102,7 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
+
   <build>
     <plugins>
       <plugin>


### PR DESCRIPTION
- Renamed new artifacts to match standards
- Removed organization as it's inherited from parent poms
- Existing artifacts remain with the same GAV for backward compatibility